### PR TITLE
Adding 3DStudio (as 3DsMax) and blender

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -9,6 +9,7 @@ Sound Forge,1991-01-01,Audacity,2000-05-28,3435 days
 WinZip,1991-04-03,7-zip,1999-06-19,2999 days
 Windows Media Player,1991-10-01,VLC media player,2001-02-01,3411 days
 Netscape Navigator,1994-12-15,Firefox,2002-09-23,2839 days
+Autodesk 3ds Max(3D Studio),1990-07-01,Blender,1994-01-08,1287 days
 FTP Explorer,1996-10-01,FileZilla,2001-06-22,1725 days
 BitKeeper,2000-05-04,Git,2005-04-07,1799 days
 YouTube,2005-02-14,PeerTube,2018-10-11,4987 days


### PR DESCRIPTION
Autodesk 3DS Max was release under "3D Studio" name in 1990, we don't have the exact date ; so i've chosen "1st july" (half of the year)
is this acceptable?

Blender was simple : the exact date is 08 january 1994