### PR TITLE
Replace Mastodon with GNU Social (Laconica)

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -12,7 +12,7 @@ Netscape Navigator,1994-12-15,Firefox,2002-09-23,2839 days
 FTP Explorer,1996-10-01,FileZilla,2001-06-22,1725 days
 BitKeeper,2000-05-04,Git,2005-04-07,1799 days
 YouTube,2005-02-14,PeerTube,2018-10-11,4987 days
-Twitter,2006-03-21,Mastodon,2016-03-16,3648 days
+Twitter,2006-03-21,GNU Social,2008-07-02,834 days
 ManyCam,2006-03-22,OBS,2012-09-01,2355 days
 Google Translate,2006-04-28,Argos Translate,2020-04-07,5093 days
 1Password,2006-06-18,Bitwarden,2016-08-10,3706 days


### PR DESCRIPTION
Also known as StatusNet. Date is from launch of identi.ca.

https://web.archive.org/web/20081222041408/http://laconi.ca/trac/
https://web.archive.org/web/20080714093008/http://controlyourself.ca/
https://arstechnica.com/information-technology/2008/07/open-source-microblogging-site-may-become-twitter-fallback/

Laconica renamed to StatusNet; StatusNet renamed to GNU Social. GNU Social spoke OStatus; Mastodon speaks ActivityPub which was based on ActivityPump which was designed to succeed OStatus, and it used to speak OStatus too outright.