### PR TITLE
MATLAB fix start date

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -1,7 +1,7 @@
 "Proprietary Product / service","Published on","Open source Alternative","Published on",TTOSA
 Unix,1973-10-01,GNU/Linux,1991-09-17,6560 days
 AutoCAD,1982-12-01,Open Cascade,1999-01-01,5875 days
-MATLAB,1984-01-01,Scilab,1990-01-01,2192 days
+MATLAB,1984-12-12,Scilab,1990-01-01,2192 days
 Adobe Illustrator,1987-03-19,Inkscape,2003-11-02,6072 days
 Photoshop,1990-02-19,GIMP,1998-06-02,3025 days
 Microsoft Office,1990-11-19,OpenOffice,2002-05-01,4181 days


### PR DESCRIPTION
MATLAB made its debut at the [1984 IEEE Conference on Decision and Control](https://fr.mathworks.com/company/newsletters/articles/a-brief-history-of-matlab.html) which was held on the [12-14 December 1984](http://ieeecss.org/event/23rd-ieee-conference-decision-and-control)