### PR TITLE
BSD was licensed freely before Linux

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -1,5 +1,5 @@
 "Proprietary Product / service","Published on","Open source Alternative","Published on",TTOSA
-Unix,1973-10-01,GNU/Linux,1991-09-17,6560 days
+Unix,1973-10-01,GNU/BSD,1989-06-01,5722 days
 AutoCAD,1982-12-01,Open Cascade,1999-01-01,5875 days
 MATLAB,1984-12-12,Scilab,1990-01-01,1846 days
 Adobe Illustrator,1987-03-19,Inkscape,2003-11-02,6072 days


### PR DESCRIPTION
According to Wikipedia: 

> Until then, all versions of BSD used proprietary AT&T Unix code, and were therefore subject to an AT&T software license. Source code licenses had become very expensive and several outside parties had expressed interest in a separate release of the networking code, which had been developed entirely outside AT&T and would not be subject to the licensing requirement. This led to Networking Release 1 (Net/1), which was made available to non-licensees of AT&T code and was [freely redistributable](https://en.wikipedia.org/wiki/Free_software) under the terms of the [BSD license](https://en.wikipedia.org/wiki/BSD_licenses). It was released in June 1989.

- https://en.wikipedia.org/wiki/Berkeley_Software_Distribution