### PR TITLE
ownCloud was formed in 2010, not Nextcloud

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -18,7 +18,7 @@ ManyCam,2006-03-22,OBS,2012-09-01,2355 days
 Google Translate,2006-04-28,Argos Translate,2020-04-07,5093 days
 1Password,2006-06-18,Bitwarden,2016-08-10,3706 days
 Heroku,2007-01-01,Dokku,2013-06-02,2344 days
-Dropbox,2007-06-01,NextCloud,2010-05-30,1094 days
+Dropbox,2007-06-01,ownCloud,2010-05-30,1094 days
 Pocket,2007-08-01,Wallabag,2013-03-31,2069 days
 Sublime Text,2008-01-18,Atom,2014-02-26,2231 days
 GitHub,2008-02-08,GitLab,2011-10-13,1343 days


### PR DESCRIPTION
https://en.wikipedia.org/wiki/OwnCloud

https://en.wikipedia.org/wiki/Nextcloud

> In April 2016 Karlitschek and most core contributors [[20]](https://en.wikipedia.org/wiki/Nextcloud#cite_note-github-statistics-20) left ownCloud Inc.[[21]](https://en.wikipedia.org/wiki/Nextcloud#cite_note-karlitschek-leaves-owncloud-21) These included some of ownCloud's staff according to sources near to the ownCloud community.[[22]](https://en.wikipedia.org/wiki/Nextcloud#cite_note-22)