### PR TITLE
Add Notion (proprietary) vs AppFlowy (open source)

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -36,7 +36,7 @@ Airtable,2013-01-01,Baserow,2019-02-15,2236 days
 Slack,2013-08-01,Mattermost,2015-10-02,792 days
 Calendly,2014-02-06,Calendso,2021-03-07,2586 days
 Discord,2015-05-13,Fosscord,2021-01-24,2083 days
-Notion,2016-01-01,AppFlowy,2021-11-13,2143 days
+Notion,2016-01-01,AppFlowy,2021-06-16,1993 days
 Figma,2016-09-27,Penpot,2021-02-02,1589 days
 Canny.io,2017-03-01,Astuto,2019-08-19,901 days
 Roam Research,2019-10-14,Foam,2020-06-14,244 days

--- a/data.csv
+++ b/data.csv
@@ -36,6 +36,7 @@ Airtable,2013-01-01,Baserow,2019-02-15,2236 days
 Slack,2013-08-01,Mattermost,2015-10-02,792 days
 Calendly,2014-02-06,Calendso,2021-03-07,2586 days
 Discord,2015-05-13,Fosscord,2021-01-24,2083 days
+Notion,2016-01-01,AppFlowy,2021-11-13,2143 days
 Figma,2016-09-27,Penpot,2021-02-02,1589 days
 Canny.io,2017-03-01,Astuto,2019-08-19,901 days
 Roam Research,2019-10-14,Foam,2020-06-14,244 days


### PR DESCRIPTION
This adds Notion vs AppFlowy to the dataset.
Notion/AppFlowy is a project management and note-taking software.

Source for Notion:
https://en.wikipedia.org/wiki/Notion_(productivity_software)
Notion's first release has no specific date. Only the year is known (2016), so we use the date 2016-01-01

Source for AppFlowy:
https://www.appflowy.io/
Initial release:
https://github.com/AppFlowy-IO/AppFlowy/releases/tag/0.0.1