### PR TITLE
Adding Algolia-Typesense

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -31,7 +31,7 @@ Twitch,2011-06-06,Owncast,2020-05-17,3268 days
 Trello,2011-09-13,Wekan,2015-05-10,1335 days
 Apple Siri,2011-10-04,SEPIA Framework,2018-05-03,2403 days
 Firebase,2012-04-12,Supabase,2019-10-12,2739 days
-Algolia Search,2012-11-21,Typesense,2018-04-04,1960 days
+Algolia Search,2012-10-10,Typesense,2015-11-10,1126 days
 Airtable,2013-01-01,NocoDB,2017-10-29,1762 days
 Airtable,2013-01-01,Baserow,2019-02-15,2236 days
 Slack,2013-08-01,Mattermost,2015-10-02,792 days

--- a/data.csv
+++ b/data.csv
@@ -31,6 +31,7 @@ Twitch,2011-06-06,Owncast,2020-05-17,3268 days
 Trello,2011-09-13,Wekan,2015-05-10,1335 days
 Apple Siri,2011-10-04,SEPIA Framework,2018-05-03,2403 days
 Firebase,2012-04-12,Supabase,2019-10-12,2739 days
+Algolia Search,2012-11-21,Typesense,2018-04-04,1960 days
 Airtable,2013-01-01,NocoDB,2017-10-29,1762 days
 Airtable,2013-01-01,Baserow,2019-02-15,2236 days
 Slack,2013-08-01,Mattermost,2015-10-02,792 days


### PR DESCRIPTION
 **Algolia-Typesense**

**Algolia Search release** : https://www.algolia.com/blog/algolia/algolia-search-is-out/ first release : 21th nov 2012

**Typesense release** : 
https://news.ycombinator.com/item?id=16765501
https://github.com/typesense/typesense/releases?page=3

direct mention of : "An Open Source Algolia Alternative" in : https://github.com/typesense/typesense
