### PR TITLE
Add IBM SPSS Statistics as propriety project

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -17,6 +17,7 @@ YouTube,2005-02-14,PeerTube,2018-10-11,4987 days
 Reddit,2005-06-23,Lemmy,2019-02-14,4984 days
 Twitter,2006-03-21,GNU Social,2008-07-02,834 days
 ManyCam,2006-03-22,OBS,2012-09-01,2355 days
+Google Analytics,2005-11-14,Matomo,2007-07-24,617 days
 Google Translate,2006-04-28,Argos Translate,2020-04-07,5093 days
 1Password,2006-06-18,Bitwarden,2016-08-10,3706 days
 Heroku,2007-01-01,Dokku,2013-06-02,2344 days

--- a/data.csv
+++ b/data.csv
@@ -1,5 +1,6 @@
 "Proprietary Product / service","Published on","Open source Alternative","Published on",TTOSA
 Unix,1973-10-01,GNU/Linux,1991-09-17,6560 days
+S Language,1976-01-01,R Language,1993-08-01,6422 days
 AutoCAD,1982-12-01,Open Cascade,1999-01-01,5875 days
 MATLAB,1984-12-12,Scilab,1990-01-01,1846 days
 Adobe Illustrator,1987-03-19,Inkscape,2003-11-02,6072 days
@@ -44,5 +45,3 @@ Figma,2016-09-27,Penpot,2021-02-02,1589 days
 Canny.io,2017-03-01,Astuto,2019-08-19,901 days
 Roam Research,2019-10-14,Foam,2020-06-14,244 days
 Clubhouse,2020-03-01,Dogehouse,2021-02-07,343 days
-S Language,1976-01-01,R Language,1993-08-01,6422 days
-

--- a/data.csv
+++ b/data.csv
@@ -31,6 +31,7 @@ Twitch,2011-06-06,Owncast,2020-05-17,3268 days
 Trello,2011-09-13,Wekan,2015-05-10,1335 days
 Apple Siri,2011-10-04,SEPIA Framework,2018-05-03,2403 days
 Firebase,2012-04-12,Supabase,2019-10-12,2739 days
+Algolia Search,2012-10-10,Typesense,2015-11-10,1126 days
 Airtable,2013-01-01,NocoDB,2017-10-29,1762 days
 Airtable,2013-01-01,Baserow,2019-02-15,2236 days
 Slack,2013-08-01,Mattermost,2015-10-02,792 days

--- a/data.csv
+++ b/data.csv
@@ -44,4 +44,4 @@ Figma,2016-09-27,Penpot,2021-02-02,1589 days
 Canny.io,2017-03-01,Astuto,2019-08-19,901 days
 Roam Research,2019-10-14,Foam,2020-06-14,244 days
 Clubhouse,2020-03-01,Dogehouse,2021-02-07,343 days
-
+IBM SPSS Statistics, 1968-01-01, GNU PSPP, 2005-08-03, 13729 days

--- a/data.csv
+++ b/data.csv
@@ -23,6 +23,7 @@ Dropbox,2007-06-01,ownCloud,2010-05-30,1094 days
 Pocket,2007-08-01,Wallabag,2013-03-31,2069 days
 Sublime Text,2008-01-18,Atom,2014-02-26,2231 days
 GitHub,2008-02-08,GitLab,2011-10-13,1343 days
+Twilio,2008-03-13,Fonoster,2018-02-04,3615 days
 Workflowy,2010-08-02,HackFlowy,2013-03-24,965 days
 Sketch,2010-09-07,Akira,2017-05-14,2441 days
 Google Authenticator,2010-09-20,andOTP,2017-07-05,2480 days

--- a/data.csv
+++ b/data.csv
@@ -15,9 +15,9 @@ FTP Explorer,1996-10-01,FileZilla,2001-06-22,1725 days
 BitKeeper,2000-05-04,Git,2005-04-07,1799 days
 YouTube,2005-02-14,PeerTube,2018-10-11,4987 days
 Reddit,2005-06-23,Lemmy,2019-02-14,4984 days
+Google Analytics,2005-11-14,Matomo,2007-07-24,617 days
 Twitter,2006-03-21,GNU Social,2008-07-02,834 days
 ManyCam,2006-03-22,OBS,2012-09-01,2355 days
-Google Analytics,2005-11-14,Matomo,2007-07-24,617 days
 Google Translate,2006-04-28,Argos Translate,2020-04-07,5093 days
 1Password,2006-06-18,Bitwarden,2016-08-10,3706 days
 Heroku,2007-01-01,Dokku,2013-06-02,2344 days

--- a/data.csv
+++ b/data.csv
@@ -7,6 +7,7 @@ Photoshop,1990-02-19,GIMP,1998-06-02,3025 days
 Microsoft Office,1990-11-19,OpenOffice,2002-05-01,4181 days
 Sound Forge,1991-01-01,Audacity,2000-05-28,3435 days
 WinZip,1991-04-03,7-zip,1999-06-19,2999 days
+Civilization,1991-09-01,Freeciv,1995-11-01,1522 days
 Windows Media Player,1991-10-01,VLC media player,2001-02-01,3411 days
 Netscape Navigator,1994-12-15,Firefox,2002-09-23,2839 days
 FTP Explorer,1996-10-01,FileZilla,2001-06-22,1725 days

--- a/data.csv
+++ b/data.csv
@@ -44,4 +44,5 @@ Figma,2016-09-27,Penpot,2021-02-02,1589 days
 Canny.io,2017-03-01,Astuto,2019-08-19,901 days
 Roam Research,2019-10-14,Foam,2020-06-14,244 days
 Clubhouse,2020-03-01,Dogehouse,2021-02-07,343 days
+S Language,1976-01-01,R Language,1993-08-01,6422 days
 


### PR DESCRIPTION
Add IBM SPSS Statistics as propriety project with GNU PSPP as the open source alternative. 
IBM SPSS Statistics website:  https://www.ibm.com/products/spss-statistics
BNU PSPSS website:  https://www.gnu.org/software/pspp/
Note:  initial release date of SPSS is approximate as only the year of release can be found in any online documentation.  The first public release of PSPP is documented on the PSPP mirror site:  http://ftp.gnu.org/gnu/pspp/.
Evidence that PSPP was directly inspired by SPSS can be found on the PSPP website, which reads "GNU PSPP is a program for statistical analysis of sampled data. It is a [free as in freedom](https://www.gnu.org/philosophy/free-sw.html) replacement for the proprietary program SPSS, and appears very similar to it with a few exceptions."  There is also evidence on the PSPP FAQ page, which reads, "PSPP is a program for statistical analysis of sampled data. It is a free replacement for the proprietary program, SPSS.  One goal of the PSPP project is compatibility with the SPSS language."